### PR TITLE
minor Bugs and correction of OS init system treatment

### DIFF
--- a/Progress.h
+++ b/Progress.h
@@ -12,10 +12,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#include <sys/types.h>
 
 /*
  * linked list members
  */
-void progress_openfoam();
+void progress_openfoam(char* cwd);
 
 #endif // PROGRESS_H

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+init_process=$(ps --no-headers -o comm 1)
+
+if [ "$init_process" = "systemd" ]; then
+    # systemd-based init system
+    echo "========================================"
+    echo "Identified systemd based OS"
+    echo "========================================"
+    install Qme_systemd /etc/systemd/system/Qme.service
+    systemctl daemon-reload
+    systemctl start Qme.service
+    systemctl enable Qme.service
+    systemctl status Qme.service
+    echo ""
+    echo "========================================"
+    :
+elif [ "$init_process" = "init" ]; then
+    # SysV init system
+    echo "========================================"
+    echo "Identified SysV init based OS"
+    echo "========================================"
+    install Qme_init /etc/init.d/Qme
+    /etc/init.d/Qme start
+    rc-update add Qme
+    echo ""
+    echo "========================================"
+    :
+else
+    echo "No valid init system found (got: $init_process)"
+    :
+fi
+
+echo "FINISHED setting up init!"

--- a/makefile
+++ b/makefile
@@ -52,18 +52,6 @@ install:
 	install -m 0777 -d $(PREFIX)/finished
 	install -m 0777 taskid $(PREFIX)/info/
 	install -m 0777 version $(PREFIX)/info/
-	install Qme_init /etc/init.d/Qme
+	./install.sh
 	install $(PRJNAME) /usr/bin
-
-	echo "systemd:"
-	echo "cp Qme_systemd /etc/systemd/system/Qme.service"
-	echo "systemctl daemon-reload"
-	echo "systemctl start Qme.service"
-	echo "systemctl enable Qme.service"
-	echo "systemctl status Qme.service"
-	echo ""
-
-	echo "Start init process:"
-	echo "	# /etc/init.d/Qme start"
-	echo "Add Qme to runlevel:"
-	echo "	# rc-update add Qme"
+	echo "DONE"


### PR DESCRIPTION
corrected error in phony systemd setup. Moved OS init treatment to bash script. Corrected two bugs in Code prevending compilation.

Previously: file was copied to init.d (sysv init based OS per instructions) by default. => prevents systemd from properly enabling service.
Both options moved to own script to auto-detect init system and execute accordingly (needs SU rights).